### PR TITLE
Don't check all targets in CI clippy

### DIFF
--- a/.github/workflows/rust_ci.yml
+++ b/.github/workflows/rust_ci.yml
@@ -23,7 +23,7 @@ jobs:
           - command: fmt
             args: --all -- --check --color always
           - command: clippy
-            args: --all-targets --all-features --workspace -- -D warnings
+            args: --all-features --workspace -- -D warnings
     steps:
       - uses: actions/checkout@v4
       - uses: Swatinem/rust-cache@v2


### PR DESCRIPTION
It fails on the examples, and it looks like there's no simple way to fix it with the ESP toolchain.