### PR TITLE
Update embedded-hal & esp-hal

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,7 +1,6 @@
 [build]
 rustflags = [
   "-C", "link-arg=-nostartfiles",
-  "-C", "link-arg=-Wl,-Tlinkall.x",
 ]
 target = "xtensa-esp32-none-elf"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,9 +11,13 @@ repository = "https://github.com/rcloran/axp192-rs"
 version = "0.1.2"
 
 [dependencies]
-embedded-hal = "0.2.7"
+embedded-hal = "1.0.0"
 
 [dev-dependencies]
-esp-backtrace = { version = "0.8.0", features = ["esp32", "panic-handler", "exception-handler", "print-uart"] }
-esp-println = { version = "0.6", features = ["esp32"] }
-esp32-hal = "0.15.0"
+esp-backtrace = { version = "0.13.0", features = ["esp32", "panic-handler", "exception-handler", "defmt"] }
+esp-println = { version = "0.10.0", features = ["esp32"] }
+esp-hal = { version="0.19.0", features=["esp32"] }
+
+[lib]
+test = false
+bench = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ version = "0.1.2"
 embedded-hal = "1.0.0"
 
 [dev-dependencies]
-esp-backtrace = { version = "0.13.0", features = ["esp32", "panic-handler", "exception-handler", "defmt"] }
+esp-backtrace = { version = "0.13.0", features = ["esp32", "panic-handler", "exception-handler", "println"] }
 esp-println = { version = "0.10.0", features = ["esp32"] }
 esp-hal = { version="0.19.0", features=["esp32"] }
 

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("cargo:rustc-link-arg-examples=-Tlinkall.x");
+}

--- a/examples/m5stack-core2.rs
+++ b/examples/m5stack-core2.rs
@@ -3,10 +3,11 @@
 
 use axp192;
 use embedded_hal as eh;
-use esp_hal::{
-    clock::ClockControl, system::SystemControl, gpio::Io, i2c::I2C, peripherals::Peripherals, prelude::*, delay::Delay,
-};
 use esp_backtrace as _;
+use esp_hal::{
+    clock::ClockControl, delay::Delay, gpio::Io, i2c::I2C, peripherals::Peripherals, prelude::*,
+    system::SystemControl,
+};
 use esp_println::println;
 
 #[entry]
@@ -24,7 +25,7 @@ fn main() -> ! {
         io.pins.gpio22,
         400u32.kHz(),
         &clocks,
-        None
+        None,
     );
 
     let mut axp = axp192::Axp192::new(i2c);

--- a/examples/m5stack-core2.rs
+++ b/examples/m5stack-core2.rs
@@ -3,8 +3,8 @@
 
 use axp192;
 use embedded_hal as eh;
-use esp32_hal::{
-    clock::ClockControl, gpio::IO, i2c::I2C, peripherals::Peripherals, prelude::*, Delay,
+use esp_hal::{
+    clock::ClockControl, system::SystemControl, gpio::Io, i2c::I2C, peripherals::Peripherals, prelude::*, delay::Delay,
 };
 use esp_backtrace as _;
 use esp_println::println;
@@ -12,19 +12,19 @@ use esp_println::println;
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.DPORT.split();
+    let system = SystemControl::new(peripherals.SYSTEM);
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
     let mut delay = Delay::new(&clocks);
 
-    let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
+    let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
 
     let i2c = I2C::new(
         peripherals.I2C0,
         io.pins.gpio21,
         io.pins.gpio22,
         400u32.kHz(),
-        &mut system.peripheral_clock_control,
         &clocks,
+        None
     );
 
     let mut axp = axp192::Axp192::new(i2c);
@@ -41,15 +41,13 @@ fn main() -> ! {
         println!("USB {usb_v}v @ {usb_a}A");
         println!("Internal temperature: {temp}°C");
 
-        delay.delay_ms(1000u32);
+        delay.delay_millis(1000u32);
     }
 }
 
 fn m5sc2_init<I2C, E>(axp: &mut axp192::Axp192<I2C>, delay: &mut Delay) -> Result<(), E>
 where
-    I2C: eh::blocking::i2c::Read<Error = E>
-        + eh::blocking::i2c::Write<Error = E>
-        + eh::blocking::i2c::WriteRead<Error = E>,
+    I2C: eh::i2c::I2c<Error = E>,
 {
     // Default setup for M5Stack Core 2
     axp.set_dcdc1_voltage(3350)?; // Voltage to provide to the microcontroller (this one!)
@@ -89,10 +87,10 @@ where
     // Actually reset the LCD
     axp.set_gpio4_output(false)?;
     axp.set_ldo3_on(true)?; // Buzz the vibration motor while intializing ¯\_(ツ)_/¯
-    delay.delay_ms(100u32);
+    delay.delay_millis(100u32);
     axp.set_gpio4_output(true)?;
     axp.set_ldo3_on(false)?;
-    delay.delay_ms(100u32);
+    delay.delay_millis(100u32);
 
     Ok(())
 }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,2 @@
 [toolchain]
 channel = "esp"
-targets = ["extensa-esp32-none-elf"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@
 #![warn(rust_2018_idioms)]
 #![no_std]
 
-use embedded_hal::blocking::i2c;
+use embedded_hal::i2c;
 
 const AXP192_ADDRESS: u8 = 0x34;
 
@@ -128,7 +128,7 @@ pub enum ShutdownDuration {
 
 impl<I2C, E> Axp192<I2C>
 where
-    I2C: i2c::Read<Error = E> + i2c::Write<Error = E> + i2c::WriteRead<Error = E>,
+    I2C: i2c::I2c<Error = E>,
 {
     /// Construct a new [`Axp192`]
     ///


### PR DESCRIPTION
Thank you for creating this valuable crate. Since version `1.0.0` of `embedded-hal` has been released and `esp32-hal` has been deprecated, I have rewritten the crate to use the latest `embedded-hal` and `esp-hal`. Please check it!