### PR TITLE
Use more modern build config flags patterns

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,7 +1,6 @@
 [build]
 rustflags = [
   "-C", "link-arg=-nostartfiles",
-  "-C", "link-arg=-Wl,-Tlinkall.x",
 ]
 target = "xtensa-esp32-none-elf"
 

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("cargo:rustc-link-arg-examples=-Tlinkall.x");
+}

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,2 @@
 [toolchain]
 channel = "esp"
-targets = ["extensa-esp32-none-elf"]


### PR DESCRIPTION
This moves a flag from `.cargo/config.toml` to `build.rs`, and seems to apply it only to the example target (ie, avoiding the lib target).